### PR TITLE
Callback no longer mandatory

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -19,8 +19,8 @@ class Environment
     /**
      * Constructor
      *
-     * @param Closure $condition Condition closure
-     * @param Closure $callback Callback closure
+     * @param \Closure $condition Condition closure
+     * @param \Closure $callback Callback closure
      *
      * @return void
      */

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -24,7 +24,7 @@ class Environment
      *
      * @return void
      */
-    public function __construct(\Closure $condition, \Closure $callback)
+    public function __construct(\Closure $condition, \Closure $callback = null)
     {
         $this->condition = $condition;
         $this->callback = $callback;
@@ -51,6 +51,8 @@ class Environment
      */
     public function run()
     {
-        call_user_func($this->callback);
+        if (is_callable($this->callback)) {
+            call_user_func($this->callback);
+        }
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -8,9 +8,9 @@ use Neemzy\Environ\Exception\NoApplicableEnvironmentException;
 class Manager
 {
     /**
-     * @var array Environment collection
+     * @var \Neemzy\Environ\Environment[] collection
      */
-    protected $environments;
+    protected $environments = array();
 
     /**
      * @var string Current environment's name
@@ -36,9 +36,9 @@ class Manager
      * Adds an environment to this instance's collection
      *
      * @param string                     $name        Environment name
-     * @param Neemzy\Environ\Environment $environment Environment instance
+     * @param \Neemzy\Environ\Environment $environment Environment instance
      *
-     * @return Neemzy\Environ\Manager Self (for chaining)
+     * @return \Neemzy\Environ\Manager Self (for chaining)
      */
     public function add($name, Environment $environment)
     {
@@ -52,7 +52,7 @@ class Manager
     /**
      * Initializes environments
      *
-     * @throws Neemzy\Environ\Exception\NoApplicableEnvironmentException
+     * @throws \Neemzy\Environ\Exception\NoApplicableEnvironmentException
      * @return void
      */
     public function init()
@@ -102,7 +102,7 @@ class Manager
      *
      * @param string $name Environment name
      *
-     * @throws Neemzy\Environ\Exception\UndefinedEnvironmentException
+     * @throws \Neemzy\Environ\Exception\UndefinedEnvironmentException
      * @return void
      */
     public function set($name)

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -55,4 +55,21 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $environment->run();
         $this->assertTrue($flag);
     }
+
+    /**
+     * Checks that not providing a callback does not trigger an error nor throw an exception
+     *
+     * @return void
+     */
+    public function testRunWithNoCallback()
+    {
+        $environment = new Environment(
+            function () {
+            }
+        );
+
+        $cogitoErgoSum = true;
+        $environment->run();
+        $this->assertTrue($cogitoErgoSum); // No error / exception has been raised at that point
+    }
 }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -9,7 +9,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * Checks adding an environment to the manager
      *
-     * @return Neemzy\Environ\Manager Manager instance
+     * @return \Neemzy\Environ\Manager Manager instance
      */
     public function testAdd()
     {
@@ -33,9 +33,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Checks setting the current environment by an invalid name
      *
      * @depends testAdd
-     * @param Neemzy\Environ\Manager Manager instance
+     * @param \Neemzy\Environ\Manager Manager instance
      *
-     * @expectedException Neemzy\Environ\Exception\UndefinedEnvironmentException
+     * @expectedException \Neemzy\Environ\Exception\UndefinedEnvironmentException
      * @return void
      */
     public function testSetWithInvalidName($manager)
@@ -49,9 +49,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Checks setting the current environment by a valid name
      *
      * @depends testAdd
-     * @param Neemzy\Environ\Manager Manager instance
+     * @param \Neemzy\Environ\Manager Manager instance
      *
-     * @return Neemzy\Environ\Manager Manager instance
+     * @return \Neemzy\Environ\Manager Manager instance
      */
     public function testSetWithValidName($manager)
     {
@@ -66,7 +66,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Checks getting the current environment's name
      *
      * @depends testSetWithValidName
-     * @param Neemzy\Environ\Manager Manager instance crafted in previous test
+     * @param \Neemzy\Environ\Manager Manager instance crafted in previous test
      *
      * @return void
      */
@@ -81,7 +81,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Checks testing the current environment by name
      *
      * @depends testSetWithValidName
-     * @param Neemzy\Environ\Manager Manager instance crafted in previous test
+     * @param \Neemzy\Environ\Manager Manager instance crafted in previous test
      *
      * @return void
      */
@@ -96,7 +96,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * Checks initializing the manager to auto-select the environment without an eligible one
      *
-     * @expectedException Neemzy\Environ\Exception\NoApplicableEnvironmentException
+     * @expectedException \Neemzy\Environ\Exception\NoApplicableEnvironmentException
      * @return void
      */
     public function testInitWithoutEligibleEnvironment()
@@ -111,7 +111,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Checks initializing the manager to auto-select the environment with an eligible one
      *
      * @depends testSetWithValidName
-     * @param Neemzy\Environ\Manager Manager instance crafted in previous test
+     * @param \Neemzy\Environ\Manager Manager instance crafted in previous test
      *
      * @return void
      */


### PR DESCRIPTION
Since sometimes we only want to detect the application's platform, there is no need to provide a callback as a required condition for detection.

Can you tag v1.0 stable please? :)

Thanks, and I love what ya doin' ;)
Ben
